### PR TITLE
Add initial project framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.py[cod]
+.env
+.venv
+
+# Node modules
+node_modules/

--- a/README.md
+++ b/README.md
@@ -3,3 +3,19 @@
 This repository contains the product and technical specification for a cornhole tournament MVP.
 See [MVP_SPEC.md](MVP_SPEC.md) for details.
 
+## Backend
+
+A minimal FastAPI app lives under `backend/`. To run it locally:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r backend/requirements.txt
+uvicorn app.main:app --reload
+```
+
+Visit `http://localhost:8000/health` for a health check endpoint.
+
+## Frontend
+
+A placeholder static page lives under `frontend/index.html`.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,9 @@
+from fastapi import FastAPI
+
+app = FastAPI(title="Cornhole Tournament API")
+
+
+@app.get("/health")
+def health_check():
+    """Simple health check endpoint."""
+    return {"status": "ok"}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.110.0
+uvicorn==0.23.2
+pytest==8.0.0
+httpx==0.27.2

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,0 +1,9 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+
+def test_health():
+    client = TestClient(app)
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Cornhole Tournament</title>
+</head>
+<body>
+  <h1>Cornhole Tournament</h1>
+  <p>Frontend coming soon.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- scaffold FastAPI backend with health check endpoint
- add pytest test for health endpoint
- create placeholder frontend index page and project README

## Testing
- `PYTHONPATH=backend pytest backend/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_68a3ce038bb4832baf5bc0962db9452e