### PR TITLE
Add basic tournament UI

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,160 @@
+const API_BASE = '';
+const TID = new URLSearchParams(window.location.search).get('tid') || 'demo';
+
+function showView(name) {
+  document.querySelectorAll('.view').forEach(v => {
+    if (v.id === `view-${name}`) {
+      v.classList.remove('hidden');
+    } else {
+      v.classList.add('hidden');
+    }
+  });
+}
+
+async function apiFetch(path, options = {}) {
+  const res = await fetch(`${API_BASE}${path}`, options);
+  if (!res.ok) throw new Error('Request failed');
+  const contentType = res.headers.get('content-type') || '';
+  if (contentType.includes('application/json')) {
+    return res.json();
+  }
+  return res.text();
+}
+
+// Navigation
+const navButtons = document.querySelectorAll('nav button');
+navButtons.forEach(btn => {
+  btn.addEventListener('click', () => {
+    const view = btn.dataset.view;
+    showView(view);
+    if (view === 'bracket') loadBracket();
+    if (view === 'schedule') loadSchedule();
+    if (view === 'nownext') loadNowNext();
+    if (view === 'rules') loadRules();
+  });
+});
+
+showView('register');
+
+// Create team
+const createForm = document.getElementById('create-team-form');
+createForm.addEventListener('submit', async e => {
+  e.preventDefault();
+  const data = {
+    team_name: createForm.team_name.value,
+    players: [{ name: createForm.player1.value }, { name: createForm.player2.value }],
+    captain_contact: createForm.contact.value
+  };
+  try {
+    const json = await apiFetch(`/t/${TID}/teams`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data)
+    });
+    document.getElementById('register-result').textContent = JSON.stringify(json);
+    createForm.reset();
+  } catch (err) {
+    document.getElementById('register-result').textContent = 'Error creating team';
+  }
+});
+
+// Join team
+const joinForm = document.getElementById('join-team-form');
+joinForm.addEventListener('submit', async e => {
+  e.preventDefault();
+  const data = {
+    team_code: joinForm.team_code.value,
+    player: joinForm.player.value
+  };
+  try {
+    const json = await apiFetch(`/t/${TID}/teams/join`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data)
+    });
+    document.getElementById('join-result').textContent = JSON.stringify(json);
+    joinForm.reset();
+  } catch (err) {
+    document.getElementById('join-result').textContent = 'Error joining team';
+  }
+});
+
+// Load bracket
+async function loadBracket() {
+  const el = document.getElementById('bracket-container');
+  el.textContent = 'Loading...';
+  try {
+    const json = await apiFetch(`/t/${TID}/bracket`);
+    el.textContent = JSON.stringify(json, null, 2);
+  } catch (err) {
+    el.textContent = 'Failed to load bracket';
+  }
+}
+
+// Load schedule
+async function loadSchedule() {
+  const table = document.getElementById('schedule-table');
+  table.innerHTML = '<tr><td>Loading...</td></tr>';
+  try {
+    const json = await apiFetch(`/t/${TID}/schedule`);
+    const matches = json.matches || [];
+    if (matches.length) {
+      table.innerHTML = '<tr><th>Match</th><th>Court</th><th>Start</th></tr>';
+      matches.forEach(m => {
+        const row = document.createElement('tr');
+        row.innerHTML = `<td>${m.matchId}</td><td>${m.court || ''}</td><td>${m.start_slot || ''}</td>`;
+        table.appendChild(row);
+      });
+    } else {
+      table.innerHTML = '<tr><td>No schedule data</td></tr>';
+    }
+  } catch (err) {
+    table.innerHTML = '<tr><td>Failed to load schedule</td></tr>';
+  }
+}
+
+// Load now/next
+async function loadNowNext() {
+  const el = document.getElementById('nownext-container');
+  el.textContent = 'Loading...';
+  try {
+    const json = await apiFetch(`/t/${TID}/nownext`);
+    el.textContent = JSON.stringify(json, null, 2);
+  } catch (err) {
+    el.textContent = 'Failed to load now/next';
+  }
+}
+
+// Load rules
+async function loadRules() {
+  const el = document.getElementById('rules-container');
+  el.textContent = 'Loading...';
+  try {
+    const text = await apiFetch(`/t/${TID}/rules`);
+    el.innerHTML = text;
+  } catch (err) {
+    el.textContent = 'Failed to load rules';
+  }
+}
+
+// Submit score
+const scoreForm = document.getElementById('score-form');
+scoreForm.addEventListener('submit', async e => {
+  e.preventDefault();
+  const data = { score: { a: parseInt(scoreForm.scoreA.value, 10), b: parseInt(scoreForm.scoreB.value, 10) } };
+  try {
+    const json = await apiFetch(`/t/${TID}/matches/${scoreForm.matchId.value}/score`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Event-PIN': scoreForm.pin.value
+      },
+      body: JSON.stringify(data)
+    });
+    document.getElementById('score-result').textContent = JSON.stringify(json);
+    scoreForm.reset();
+    loadBracket();
+  } catch (err) {
+    document.getElementById('score-result').textContent = 'Error submitting score';
+  }
+});

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,9 +3,70 @@
 <head>
   <meta charset="UTF-8" />
   <title>Cornhole Tournament</title>
+  <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <h1>Cornhole Tournament</h1>
-  <p>Frontend coming soon.</p>
+  <nav>
+    <button data-view="register">Register</button>
+    <button data-view="bracket">Bracket</button>
+    <button data-view="schedule">Schedule</button>
+    <button data-view="nownext">Now / Next</button>
+    <button data-view="score">Score</button>
+    <button data-view="rules">Rules</button>
+  </nav>
+
+  <section id="view-register" class="view">
+    <h2>Team Registration</h2>
+    <form id="create-team-form">
+      <label>Team Name <input name="team_name" required></label>
+      <label>Player 1 <input name="player1" required></label>
+      <label>Player 2 <input name="player2" required></label>
+      <label>Captain Contact <input name="contact" required></label>
+      <button type="submit">Create Team</button>
+    </form>
+    <div id="register-result" class="result"></div>
+
+    <h3>Join Existing Team</h3>
+    <form id="join-team-form">
+      <label>Team Code <input name="team_code" required></label>
+      <label>Your Name <input name="player" required></label>
+      <button type="submit">Join Team</button>
+    </form>
+    <div id="join-result" class="result"></div>
+  </section>
+
+  <section id="view-bracket" class="view hidden">
+    <h2>Bracket</h2>
+    <pre id="bracket-container">Loading...</pre>
+  </section>
+
+  <section id="view-schedule" class="view hidden">
+    <h2>Schedule</h2>
+    <table id="schedule-table"></table>
+  </section>
+
+  <section id="view-nownext" class="view hidden">
+    <h2>Now / Next</h2>
+    <pre id="nownext-container">Loading...</pre>
+  </section>
+
+  <section id="view-score" class="view hidden">
+    <h2>Submit Score</h2>
+    <form id="score-form">
+      <label>Match ID <input name="matchId" required></label>
+      <label>Team A Score <input type="number" name="scoreA" required></label>
+      <label>Team B Score <input type="number" name="scoreB" required></label>
+      <label>PIN <input type="password" name="pin" required></label>
+      <button type="submit">Submit Score</button>
+    </form>
+    <div id="score-result" class="result"></div>
+  </section>
+
+  <section id="view-rules" class="view hidden">
+    <h2>Rules</h2>
+    <div id="rules-container">Loading...</div>
+  </section>
+
+  <script src="app.js"></script>
 </body>
 </html>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,0 +1,26 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 20px;
+}
+
+nav {
+  margin-bottom: 20px;
+}
+
+nav button {
+  margin-right: 10px;
+}
+
+.view.hidden {
+  display: none;
+}
+
+.result {
+  margin-top: 10px;
+  color: green;
+}
+
+pre {
+  background: #f5f5f5;
+  padding: 10px;
+}


### PR DESCRIPTION
## Summary
- Create static SPA shell with navigation for registration, bracket, schedule, score submission, and rules
- Implement client-side JS for creating and joining teams, viewing tournament data, and submitting scores
- Add basic styling for layout and content sections

## Testing
- `PYTHONPATH=backend pytest backend/tests/test_health.py`

------
https://chatgpt.com/codex/tasks/task_e_68a3d1a2b02c832baab33f08b9e51a38